### PR TITLE
Added Dr. Ramanan to peoples.md 

### DIFF
--- a/people.md
+++ b/people.md
@@ -155,4 +155,4 @@ and INRIA Paris-Rocquencourt)
       * [Daniel Goldman](http://www.adobe.com/technology/people/seattle/dan-goldman.html) (Adobe)
    * [Philippe Lacroute](http://www.lacroute.org/lacroute/) (Stanford University)
    
- * [Deva Ramanan](https://www.cs.cmu.edu/~deva/) (CMU)
+* [Deva Ramanan](https://www.cs.cmu.edu/~deva/) (CMU)

--- a/people.md
+++ b/people.md
@@ -155,4 +155,4 @@ and INRIA Paris-Rocquencourt)
       * [Daniel Goldman](http://www.adobe.com/technology/people/seattle/dan-goldman.html) (Adobe)
    * [Philippe Lacroute](http://www.lacroute.org/lacroute/) (Stanford University)
    
-[Deva Ramanan](https://www.cs.cmu.edu/~deva/) (CMU)
+ * [Deva Ramanan](https://www.cs.cmu.edu/~deva/) (CMU)

--- a/people.md
+++ b/people.md
@@ -154,3 +154,5 @@ and INRIA Paris-Rocquencourt)
       * [Yung-Yu Chuang](http://www.csie.ntu.edu.tw/~cyy/) (National Taiwan University)
       * [Daniel Goldman](http://www.adobe.com/technology/people/seattle/dan-goldman.html) (Adobe)
    * [Philippe Lacroute](http://www.lacroute.org/lacroute/) (Stanford University)
+   
+[Deva Ramanan](https://www.cs.cmu.edu/~deva/) (CMU)

--- a/people.md
+++ b/people.md
@@ -155,4 +155,4 @@ and INRIA Paris-Rocquencourt)
       * [Daniel Goldman](http://www.adobe.com/technology/people/seattle/dan-goldman.html) (Adobe)
    * [Philippe Lacroute](http://www.lacroute.org/lacroute/) (Stanford University)
    
-* [Deva Ramanan](https://www.cs.cmu.edu/~deva/) (CMU)
+[Deva Ramanan](https://www.cs.cmu.edu/~deva/) (CMU)


### PR DESCRIPTION
Dr. Ramanan is a notable professor at CMU within their vision group.  He somewhat recently transitioned from UC-Irvine to CMU, but is always on the forefront of his field.