### PR TITLE
Add Autodistill to a new section of the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Non-uniform Deblurring
  * [Edge Boxes](https://github.com/pdollar/edges)
  * [ReInspect](https://github.com/Russell91/ReInspect)
 
-### Image Distillation
+### Distillation
 
 * [Autodistill: Images to inference with no labeling (use foundation models to train supervised models)](https://github.com/autodistill/autodistill)
 

--- a/README.md
+++ b/README.md
@@ -538,6 +538,10 @@ Non-uniform Deblurring
  * [Edge Boxes](https://github.com/pdollar/edges)
  * [ReInspect](https://github.com/Russell91/ReInspect)
 
+### Image Distillation
+
+* [Autodistill: Images to inference with no labeling (use foundation models to train supervised models)](https://github.com/autodistill/autodistill)
+
 #### Nearest Neighbor Search
 
 ###### General purpose nearest neighbor search


### PR DESCRIPTION
This PR adds a new `Distillation` section to the README, under which [Autodistill](https://github.com/autodistill/autodistill), an open source ecosystem for using foundation vision models to train smaller models is added.