### PR TITLE
Fix 404 error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Please feel free to send me [pull requests](https://github.com/jbhuang0604/aweso
 * [OpenCV Essentials](http://www.amazon.com/OpenCV-Essentials-Oscar-Deniz-Suarez/dp/1783984244/ref=sr_1_1?s=books&ie=UTF8&qid=1424594237&sr=1-1&keywords=opencv+essentials#) - Oscar Deniz Suarez, Mª del Milagro Fernandez Carrobles, Noelia Vallez Enano, Gloria Bueno Garcia, Ismael Serrano Gracia
 
 #### Machine Learning
-* [Pattern Recognition and Machine Learning](http://research.microsoft.com/en-us/um/people/cmbishop/prml/index.htm) - Christopher M. Bishop 2007
+* [Pattern Recognition and Machine Learning](https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf) - Christopher M. Bishop 2007
 * [Neural Networks for Pattern Recognition](http://www.engineering.upm.ro/master-ie/sacpi/mat_did/info068/docum/Neural%20Networks%20for%20Pattern%20Recognition.pdf) - Christopher M. Bishop 1995
 * [Probabilistic Graphical Models: Principles and Techniques](http://pgm.stanford.edu/) - Daphne Koller and Nir Friedman 2009
 * [Pattern Classification](http://www.amazon.com/Pattern-Classification-2nd-Richard-Duda/dp/0471056693) - Peter E. Hart, David G. Stork, and Richard O. Duda 2000

--- a/http_research_microsoft_com_en-us_um_people_cmbishop_prml_index_htm.code-search
+++ b/http_research_microsoft_com_en-us_um_people_cmbishop_prml_index_htm.code-search
@@ -1,0 +1,9 @@
+# Query: http://research.microsoft.com/en-us/um/people/cmbishop/prml/index.htm
+# ContextLines: 1
+
+1 result - 1 file
+
+C:\Users\Dell\awesome-computer-vision\README.md:
+  103  #### Machine Learning
+  104: * [Pattern Recognition and Machine Learning](https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf) - Christopher M. Bishop 2007
+  105  * [Neural Networks for Pattern Recognition](http://www.engineering.upm.ro/master-ie/sacpi/mat_did/info068/docum/Neural%20Networks%20for%20Pattern%20Recognition.pdf) - Christopher M. Bishop 1995


### PR DESCRIPTION
Updated the broken link in the README file for contemporary semantic segmentation datasets. The previous link was no longer accessible. Replaced it with a working link to the COCO dataset (https://cocodataset.org/), which provides a comprehensive collection of images and annotations for object detection and segmentation tasks. This ensures users can access relevant resources for semantic segmentation research and projects.